### PR TITLE
詳細画面の編集と削除ボタンの表示対象修正

### DIFF
--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,7 +5,7 @@
         <%= @prototype.title %>
       </p>
       <%= link_to @prototype.user.name, user_path(@prototype.user.id), class: :prototype__user %>
-      <% if user_signed_in? && current_user.id = @prototype.user.id %>
+      <% if user_signed_in? && current_user.id == @prototype.user.id %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
           <%= link_to "削除する", "/prototypes/#{@prototype.id}", data: { turbo_method: :delete }, class: :prototype__btn %>


### PR DESCRIPTION
投稿者ユーザーのみが下記を実行可能。
編集と削除ボタンが表示される
編集と削除ができる