### PR TITLE
コメント表示の修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -22,7 +22,7 @@ class PrototypesController < ApplicationController
 
   def show
     @comment = Comment.new()
-    @comments = Comment.includes(:prototype, :user)
+    @comments = @prototype.comments.includes(:user)
   end
 
   def edit


### PR DESCRIPTION
投稿する前からコメントとコメント投稿者名が表示される状態を解消